### PR TITLE
fix: Windows python3 兼容性、非交互安装、调试日志

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ From now on, every time Claude Code finishes a response, you'll receive a Lark c
 
 ## Configuration
 
-Config file: `~/.config/claude-lark/config.json` (permissions 600):
+Config file: `~/.config/claude-lark/config.json` (permissions 600 on macOS/Linux; on Windows, ensure the file is not readable by other users):
 
 ```json
 {
@@ -117,6 +117,13 @@ Control which events trigger notifications:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CLAUDE_LARK_TZ_OFFSET` | Timezone offset from UTC (hours) | `8` (Asia/Shanghai) |
+| `CLAUDE_LARK_DEBUG` | Enable debug logging to `~/.config/claude-lark/debug.log` | Off |
+
+To enable debug logging (useful for troubleshooting):
+
+```bash
+export CLAUDE_LARK_DEBUG=1
+```
 
 ---
 
@@ -224,7 +231,7 @@ chmod 600 ~/.config/claude-lark/config.json
 
 ### 2. Add Claude Code hooks
 
-Add to `~/.claude/settings.json`:
+Add to `~/.claude/settings.json` (use `python` instead of `python3` on Windows):
 
 ```json
 {
@@ -308,6 +315,10 @@ claude-lark/
 - **Windows**: PowerShell 5.1+ (built-in)
 
 ## FAQ
+
+**Q: Notifications aren't working, how do I debug?**
+
+Set `CLAUDE_LARK_DEBUG=1` as an environment variable. The script will write detailed logs to `~/.config/claude-lark/debug.log`, showing config loading, API calls, and any errors.
 
 **Q: Will it slow down Claude Code?**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -79,7 +79,7 @@ chmod +x scripts/install.sh
 
 ## 配置
 
-配置文件位于 `~/.config/claude-lark/config.json`（权限 600，仅用户可读）：
+配置文件位于 `~/.config/claude-lark/config.json`（macOS/Linux 下权限 600 仅用户可读；Windows 上请确保文件不被其他用户读取）：
 
 ```json
 {
@@ -119,6 +119,13 @@ chmod +x scripts/install.sh
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `CLAUDE_LARK_TZ_OFFSET` | 时区偏移（相对 UTC 的小时数） | `8`（Asia/Shanghai） |
+| `CLAUDE_LARK_DEBUG` | 开启调试日志，写入 `~/.config/claude-lark/debug.log` | 关闭 |
+
+开启调试日志（排查问题时使用）：
+
+```bash
+export CLAUDE_LARK_DEBUG=1
+```
 
 ---
 
@@ -226,7 +233,7 @@ chmod 600 ~/.config/claude-lark/config.json
 
 ### 2. 编辑 Claude Code 设置
 
-在 `~/.claude/settings.json` 的 `hooks` 中添加：
+在 `~/.claude/settings.json` 的 `hooks` 中添加（Windows 上请用 `python` 替代 `python3`）：
 
 ```json
 {
@@ -307,6 +314,10 @@ claude-lark/
 - **Windows**: PowerShell 5.1+（系统自带）
 
 ## FAQ
+
+**Q: 通知没有收到，怎么排查？**
+
+设置环境变量 `CLAUDE_LARK_DEBUG=1`，脚本会将详细日志写入 `~/.config/claude-lark/debug.log`，包括配置加载、API 调用和错误信息。
 
 **Q: 会不会拖慢 Claude Code？**
 

--- a/claude_lark_notify.py
+++ b/claude_lark_notify.py
@@ -11,10 +11,12 @@ Config: ~/.config/claude-lark/config.json
 from __future__ import annotations
 
 import json
+import os
 import platform
 import subprocess
 import sys
 import time
+import traceback
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone, timedelta
@@ -24,6 +26,23 @@ from pathlib import Path
 CONFIG_DIR = Path.home() / ".config" / "claude-lark"
 CONFIG_PATH = CONFIG_DIR / "config.json"
 TOKEN_CACHE_PATH = CONFIG_DIR / ".token_cache"
+DEBUG_LOG_PATH = CONFIG_DIR / "debug.log"
+
+# ── Debug logging ────────────────────────────────────────────────────
+_DEBUG = os.environ.get("CLAUDE_LARK_DEBUG", "").strip() in ("1", "true", "yes")
+
+
+def _debug_log(msg: str) -> None:
+    """Write a debug message to the log file (only when CLAUDE_LARK_DEBUG=1)."""
+    if not _DEBUG:
+        return
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(DEBUG_LOG_PATH, "a", encoding="utf-8") as f:
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            f.write(f"[{ts}] {msg}\n")
+    except OSError:
+        pass
 
 # ── Lark API ─────────────────────────────────────────────────────────
 LARK_TOKEN_URL = (
@@ -44,19 +63,26 @@ def _load_config() -> dict | None:
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         if not all(cfg.get(k) for k in ("app_id", "app_secret", "open_id")):
+            _debug_log(f"Config incomplete: {CONFIG_PATH}")
             return None
+        _debug_log(f"Config loaded: app_id={cfg['app_id']}, open_id={cfg['open_id']}")
         return cfg
-    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+    except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+        _debug_log(f"Config load failed: {e}")
         return None
 
 
 def _read_stdin() -> dict:
     try:
         if sys.stdin.isatty():
+            _debug_log("stdin is a tty, no event data")
             return {}
         raw = sys.stdin.read()
-        return json.loads(raw) if raw.strip() else {}
-    except (json.JSONDecodeError, IOError):
+        event = json.loads(raw) if raw.strip() else {}
+        _debug_log(f"Event received: {event.get('hook_event_name', '?')}, cwd={event.get('cwd', '?')}")
+        return event
+    except (json.JSONDecodeError, IOError) as e:
+        _debug_log(f"stdin read failed: {e}")
         return {}
 
 
@@ -93,12 +119,15 @@ def _fetch_tenant_token(app_id: str, app_secret: str) -> str | None:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
             data = json.loads(resp.read())
         if data.get("code") != 0:
+            _debug_log(f"Token fetch failed: code={data.get('code')}, msg={data.get('msg')}")
             return None
         token = data.get("tenant_access_token", "")
         if token:
             _save_token_cache(token, data.get("expire", 7200))
+            _debug_log("Token fetched and cached")
         return token or None
-    except (urllib.error.URLError, json.JSONDecodeError, OSError):
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
+        _debug_log(f"Token fetch error: {e}")
         return None
 
 
@@ -295,7 +324,6 @@ def _get_git_info(cwd: str) -> dict:
 
 def _now_str() -> str:
     # Use TZ env or default to Asia/Shanghai (UTC+8)
-    import os
     offset_hours = int(os.environ.get("CLAUDE_LARK_TZ_OFFSET", "8"))
     local = datetime.now(timezone.utc) + timedelta(hours=offset_hours)
     return local.strftime("%Y-%m-%d %H:%M:%S")
@@ -640,8 +668,15 @@ def send_card(token: str, open_id: str, card: dict) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-            return json.loads(resp.read()).get("code") == 0
-    except (urllib.error.URLError, json.JSONDecodeError, OSError):
+            result = json.loads(resp.read())
+            success = result.get("code") == 0
+            if success:
+                _debug_log("Card sent successfully")
+            else:
+                _debug_log(f"Card send failed: code={result.get('code')}, msg={result.get('msg')}")
+            return success
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
+        _debug_log(f"Card send error: {e}")
         return False
 
 
@@ -649,18 +684,23 @@ def send_card(token: str, open_id: str, card: dict) -> bool:
 
 
 def main() -> None:
+    _debug_log("=== claude-lark notify start ===")
+
     config = _load_config()
     if not config:
+        _debug_log("No config, exiting")
         return
 
     event = _read_stdin()
     if not event:
+        _debug_log("No event data, exiting")
         return
 
     # Event filtering
     event_name = event.get("hook_event_name", "")
     allowed = config.get("events", DEFAULT_EVENTS)
     if event_name and event_name not in allowed:
+        _debug_log(f"Event '{event_name}' not in allowed list {allowed}, skipping")
         return
 
     # Parse transcript for rich stats
@@ -683,6 +723,10 @@ def main() -> None:
         send_card(token, config["open_id"], card)
         session_id = event.get("session_id", "")
         _save_checkpoint(session_id, stats)
+    else:
+        _debug_log("Failed to get token, notification not sent")
+
+    _debug_log("=== claude-lark notify end ===")
 
 
 if __name__ == "__main__":

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,6 +4,7 @@
     claude-lark installer for Windows
 .DESCRIPTION
     Configures Claude Code hooks to send Lark (Feishu) notifications.
+    Supports non-interactive mode when config already exists.
 .PARAMETER AppId
     Lark Bot App ID
 .PARAMETER AppSecret
@@ -62,144 +63,182 @@ Write-Host "  ──────────────────────
 Write-Host ""
 
 # ── Check Python ─────────────────────────────────────────────────────
-try {
-    $pyVer = & python3 --version 2>&1
-    Write-Ok "python3 $pyVer"
-} catch {
+# Detect the actual working Python 3 command.
+# On Windows, "python3" is often a Microsoft Store stub (exit code 49),
+# so we test each candidate and use the first one that actually works.
+$PythonCmd = $null
+foreach ($candidate in @("python3", "python")) {
     try {
-        $pyVer = & python --version 2>&1
-        if ($pyVer -match "Python 3") {
-            Write-Ok "python $pyVer"
-            Set-Alias -Name python3 -Value python -Scope Script
-        } else { Write-Err "需要 Python 3.8+，当前版本: $pyVer" }
-    } catch { Write-Err "未找到 Python，请先安装 Python 3.8+" }
+        $pyOut = & $candidate --version 2>&1
+        if ($LASTEXITCODE -eq 0 -and "$pyOut" -match "Python 3") {
+            $PythonCmd = $candidate
+            Write-Ok "$candidate $pyOut"
+            break
+        }
+    } catch { }
 }
+if (-not $PythonCmd) { Write-Err "未找到 Python 3.8+，请先安装 Python" }
 
 if (-not (Test-Path $NotifyScript)) {
     Write-Err "未找到 claude_lark_notify.py: $NotifyScript"
 }
 
-# ══════════════════════════════════════════════════════════════════════
-#  Step 1: Bot Credentials
-# ══════════════════════════════════════════════════════════════════════
-Write-Step "Step 1/4  飞书机器人凭证"
-
-if (-not $AppId) {
-    $existing = Get-ConfigValue "app_id"
-    if ($existing) {
-        $input = Read-Host "  App ID [$existing]"
-        $AppId = if ($input) { $input } else { $existing }
-    } else {
-        $AppId = Read-Host "  App ID"
-    }
-}
-if (-not $AppId) { Write-Err "App ID 不能为空" }
-
-if (-not $AppSecret) {
-    $existing = Get-ConfigValue "app_secret"
-    if ($existing) {
-        $secureInput = Read-Host "  App Secret [已保存，回车跳过]" -AsSecureString
-        $plainInput = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
-            [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput))
-        $AppSecret = if ($plainInput) { $plainInput } else { $existing }
-    } else {
-        $secureInput = Read-Host "  App Secret" -AsSecureString
-        $AppSecret = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
-            [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput))
-    }
-}
-if (-not $AppSecret) { Write-Err "App Secret 不能为空" }
-
-# ══════════════════════════════════════════════════════════════════════
-#  Step 2: Verify API
-# ══════════════════════════════════════════════════════════════════════
-Write-Step "Step 2/4  验证 API 连接"
-
-$tokenBody = @{ app_id = $AppId; app_secret = $AppSecret } | ConvertTo-Json
-try {
-    $tokenResp = Invoke-RestMethod -Uri "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal/" `
-        -Method Post -ContentType "application/json" -Body $tokenBody
-    if ($tokenResp.code -ne 0) { Write-Err "API 连接失败: $($tokenResp.msg)" }
-    $Token = $tokenResp.tenant_access_token
-    Write-Ok "飞书 API 连接成功"
-} catch {
-    Write-Err "API 连接失败，请检查 App ID 和 App Secret"
-}
-
-# ══════════════════════════════════════════════════════════════════════
-#  Step 3: Get Open ID
-# ══════════════════════════════════════════════════════════════════════
-Write-Step "Step 3/4  确定你的飞书身份"
-
-if (-not $OpenId -and -not $Phone -and -not $Email) {
-    $existing = Get-ConfigValue "open_id"
-    Write-Host ""
-    Write-Host "  选择查找方式:" -ForegroundColor DarkGray
-    Write-Host "  1) 手机号（推荐）"
-    Write-Host "  2) 邮箱"
-    Write-Host "  3) 直接输入 Open ID"
-    if ($existing) { Write-Host "  4) 使用已保存的 Open ID ($existing)" -ForegroundColor DarkGray }
-    Write-Host ""
-    $choice = Read-Host "  请选择 [1]"
-    if (-not $choice) { $choice = "1" }
-
-    switch ($choice) {
-        "1" { $Phone = Read-Host "  飞书手机号" }
-        "2" { $Email = Read-Host "  飞书邮箱" }
-        "3" { $OpenId = Read-Host "  Open ID" }
-        "4" { $OpenId = $existing }
-        default { Write-Err "无效选择" }
+# ── Check for existing complete config (non-interactive mode) ────────
+$HasCompleteConfig = $false
+if (Test-Path $ConfigFile) {
+    $existingAppId = Get-ConfigValue "app_id"
+    $existingAppSecret = Get-ConfigValue "app_secret"
+    $existingOpenId = Get-ConfigValue "open_id"
+    if ($existingAppId -and $existingAppSecret -and $existingOpenId) {
+        $HasCompleteConfig = $true
     }
 }
 
-# Lookup by phone or email
-if ($Phone -or $Email) {
-    Write-Info "查询 Open ID..."
-    $lookupBody = @{}
-    if ($Phone) { $lookupBody["mobiles"] = @($Phone) }
-    if ($Email) { $lookupBody["emails"] = @($Email) }
+# If config is complete AND no credentials were passed as arguments,
+# skip Steps 1-3 and go straight to hook installation.
+$SkipCredentials = $HasCompleteConfig -and (-not $AppId) -and (-not $AppSecret) -and `
+                   (-not $Phone) -and (-not $Email) -and (-not $OpenId)
 
+if ($SkipCredentials) {
+    Write-Info "检测到完整配置文件，跳过凭证设置"
+    $AppId = $existingAppId
+    $AppSecret = $existingAppSecret
+    $OpenId = $existingOpenId
+
+    # Quick API verification
+    Write-Step "Step 1/2  验证 API 连接"
+    $tokenBody = @{ app_id = $AppId; app_secret = $AppSecret } | ConvertTo-Json
     try {
-        $lookupResp = Invoke-RestMethod `
-            -Uri "https://open.feishu.cn/open-apis/contact/v3/users/batch_get_id?user_id_type=open_id" `
-            -Method Post -ContentType "application/json" `
-            -Headers @{ Authorization = "Bearer $Token" } `
-            -Body ($lookupBody | ConvertTo-Json)
-
-        if ($lookupResp.code -ne 0) { Write-Err "查询失败: $($lookupResp.msg)" }
-        $users = $lookupResp.data.user_list
-        if (-not $users -or -not $users[0].user_id) { Write-Err "未找到用户" }
-        $OpenId = $users[0].user_id
-        Write-Ok "查询成功: $OpenId"
+        $tokenResp = Invoke-RestMethod -Uri "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal/" `
+            -Method Post -ContentType "application/json" -Body $tokenBody
+        if ($tokenResp.code -ne 0) { Write-Err "API 连接失败: $($tokenResp.msg)" }
+        Write-Ok "飞书 API 连接成功"
     } catch {
-        Write-Err "查询失败: $_"
+        Write-Err "API 连接失败，请检查配置文件中的 App ID 和 App Secret"
     }
+
+    Write-Step "Step 2/2  安装 hooks"
+} else {
+    # ══════════════════════════════════════════════════════════════════
+    #  Step 1: Bot Credentials
+    # ══════════════════════════════════════════════════════════════════
+    Write-Step "Step 1/4  飞书机器人凭证"
+
+    if (-not $AppId) {
+        $existing = Get-ConfigValue "app_id"
+        if ($existing) {
+            $input = Read-Host "  App ID [$existing]"
+            $AppId = if ($input) { $input } else { $existing }
+        } else {
+            $AppId = Read-Host "  App ID"
+        }
+    }
+    if (-not $AppId) { Write-Err "App ID 不能为空" }
+
+    if (-not $AppSecret) {
+        $existing = Get-ConfigValue "app_secret"
+        if ($existing) {
+            $secureInput = Read-Host "  App Secret [已保存，回车跳过]" -AsSecureString
+            $plainInput = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+                [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput))
+            $AppSecret = if ($plainInput) { $plainInput } else { $existing }
+        } else {
+            $secureInput = Read-Host "  App Secret" -AsSecureString
+            $AppSecret = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+                [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput))
+        }
+    }
+    if (-not $AppSecret) { Write-Err "App Secret 不能为空" }
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Step 2: Verify API
+    # ══════════════════════════════════════════════════════════════════
+    Write-Step "Step 2/4  验证 API 连接"
+
+    $tokenBody = @{ app_id = $AppId; app_secret = $AppSecret } | ConvertTo-Json
+    try {
+        $tokenResp = Invoke-RestMethod -Uri "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal/" `
+            -Method Post -ContentType "application/json" -Body $tokenBody
+        if ($tokenResp.code -ne 0) { Write-Err "API 连接失败: $($tokenResp.msg)" }
+        $Token = $tokenResp.tenant_access_token
+        Write-Ok "飞书 API 连接成功"
+    } catch {
+        Write-Err "API 连接失败，请检查 App ID 和 App Secret"
+    }
+
+    # ══════════════════════════════════════════════════════════════════
+    #  Step 3: Get Open ID
+    # ══════════════════════════════════════════════════════════════════
+    Write-Step "Step 3/4  确定你的飞书身份"
+
+    if (-not $OpenId -and -not $Phone -and -not $Email) {
+        $existing = Get-ConfigValue "open_id"
+        Write-Host ""
+        Write-Host "  选择查找方式:" -ForegroundColor DarkGray
+        Write-Host "  1) 手机号（推荐）"
+        Write-Host "  2) 邮箱"
+        Write-Host "  3) 直接输入 Open ID"
+        if ($existing) { Write-Host "  4) 使用已保存的 Open ID ($existing)" -ForegroundColor DarkGray }
+        Write-Host ""
+        $choice = Read-Host "  请选择 [1]"
+        if (-not $choice) { $choice = "1" }
+
+        switch ($choice) {
+            "1" { $Phone = Read-Host "  飞书手机号" }
+            "2" { $Email = Read-Host "  飞书邮箱" }
+            "3" { $OpenId = Read-Host "  Open ID" }
+            "4" { $OpenId = $existing }
+            default { Write-Err "无效选择" }
+        }
+    }
+
+    # Lookup by phone or email
+    if ($Phone -or $Email) {
+        Write-Info "查询 Open ID..."
+        $lookupBody = @{}
+        if ($Phone) { $lookupBody["mobiles"] = @($Phone) }
+        if ($Email) { $lookupBody["emails"] = @($Email) }
+
+        try {
+            $lookupResp = Invoke-RestMethod `
+                -Uri "https://open.feishu.cn/open-apis/contact/v3/users/batch_get_id?user_id_type=open_id" `
+                -Method Post -ContentType "application/json" `
+                -Headers @{ Authorization = "Bearer $Token" } `
+                -Body ($lookupBody | ConvertTo-Json)
+
+            if ($lookupResp.code -ne 0) { Write-Err "查询失败: $($lookupResp.msg)" }
+            $users = $lookupResp.data.user_list
+            if (-not $users -or -not $users[0].user_id) { Write-Err "未找到用户" }
+            $OpenId = $users[0].user_id
+            Write-Ok "查询成功: $OpenId"
+        } catch {
+            Write-Err "查询失败: $_"
+        }
+    }
+
+    if (-not $OpenId) { Write-Err "Open ID 不能为空" }
+
+    Write-Step "Step 4/4  安装"
+
+    # Write config
+    New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+    $config = @{
+        app_id     = $AppId
+        app_secret = $AppSecret
+        open_id    = $OpenId
+        events     = @("Stop", "Notification")
+    } | ConvertTo-Json -Depth 3
+    Set-Content -Path $ConfigFile -Value $config -Encoding UTF8
+    Write-Ok "配置已保存  $ConfigFile"
+    Write-Warn "Windows 上 config.json 无法通过 chmod 保护，请确保文件不被其他用户读取"
 }
 
-if (-not $OpenId) { Write-Err "Open ID 不能为空" }
-
-# ══════════════════════════════════════════════════════════════════════
-#  Step 4: Install
-# ══════════════════════════════════════════════════════════════════════
-Write-Step "Step 4/4  安装"
-
-# Write config
-New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
-$config = @{
-    app_id     = $AppId
-    app_secret = $AppSecret
-    open_id    = $OpenId
-    events     = @("Stop", "Notification")
-} | ConvertTo-Json -Depth 3
-Set-Content -Path $ConfigFile -Value $config -Encoding UTF8
-Write-Ok "配置已保存  $ConfigFile"
-
-# Install Claude Code hooks
+# ── Install Claude Code hooks (shared by both paths) ─────────────────
 $claudeDir = Join-Path $HOME ".claude"
 New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null
 
-# Use forward slashes in the command for cross-platform compatibility
-$hookCmd = "python3 $($NotifyScript -replace '\\','/')"
+# Use the detected Python command (python or python3) in hook command
+$hookCmd = "$PythonCmd $($NotifyScript -replace '\\','/')"
 $hookEntry = @{
     matcher = ""
     hooks   = @(@{ type = "command"; command = $hookCmd; timeout = 30 })
@@ -222,7 +261,7 @@ if (-not $raw) { $raw = "{}" }
 # Use Python for safe JSON merge (PowerShell JSON handling is fragile)
 $env:SETTINGS_FILE = $SettingsFile
 $env:HOOK_CMD = $hookCmd
-python3 -c @"
+& $PythonCmd -c @"
 import json, os
 path = os.environ['SETTINGS_FILE']
 hook_cmd = os.environ['HOOK_CMD']
@@ -250,7 +289,7 @@ if (-not $sendTest -or $sendTest -match "^[Yy]") {
         session_id = "install-test"
         last_assistant_message = "claude-lark 安装成功！你现在可以收到 Claude Code 的飞书通知了。"
     } | ConvertTo-Json -Compress
-    $testPayload | python3 $NotifyScript
+    $testPayload | & $PythonCmd $NotifyScript
     Write-Ok "测试通知已发送，请查看飞书"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@
 #   ./install.sh --phone 138xxxx        # Auto-lookup open_id by phone
 #   ./install.sh --email foo@bar.com    # Auto-lookup open_id by email
 #   ./install.sh --open-id ou_xxx       # Direct open_id
+#   ./install.sh --hooks-only           # Skip credentials, only install hooks
 #
 set -euo pipefail
 
@@ -39,9 +40,11 @@ while [[ $# -gt 0 ]]; do
         --app-secret) APP_SECRET="$2"; shift 2 ;;
         --phone)      PHONE="$2";      shift 2 ;;
         --email)      EMAIL="$2";      shift 2 ;;
+        --hooks-only) HOOKS_ONLY=true; shift ;;
         -h|--help)
             echo "Usage: $0 [--phone 138xxx | --email x@y.com | --open-id ou_xxx]"
             echo "       [--app-id cli_xxx] [--app-secret xxx]"
+            echo "       [--hooks-only]  # Skip credentials, only install hooks"
             exit 0 ;;
         *) error "Unknown argument: $1" ;;
     esac
@@ -66,6 +69,45 @@ _cfg_val() {
     python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('$1',''))" 2>/dev/null
 }
 
+# ── Auto-detect non-interactive mode ─────────────────────────────────
+# If --hooks-only is set, or config already has complete credentials and
+# no credential arguments were passed, skip Steps 1-3.
+if [[ "${HOOKS_ONLY:-false}" != "true" && -z "$APP_ID" && -z "$APP_SECRET" && \
+      -z "$PHONE" && -z "$EMAIL" && -z "$OPEN_ID" ]]; then
+    # Check if config already has all required fields
+    _existing_app_id=$(_cfg_val app_id) || _existing_app_id=""
+    _existing_secret=$(_cfg_val app_secret) || _existing_secret=""
+    _existing_oid=$(_cfg_val open_id) || _existing_oid=""
+    if [[ -n "$_existing_app_id" && -n "$_existing_secret" && -n "$_existing_oid" ]]; then
+        HOOKS_ONLY=true
+        info "检测到完整配置文件，跳过凭证设置"
+    fi
+fi
+
+if [[ "${HOOKS_ONLY:-false}" == "true" ]]; then
+    # Verify config exists
+    [[ -f "$CONFIG_FILE" ]] || error "配置文件不存在: $CONFIG_FILE，请先放置配置文件"
+    APP_ID=$(_cfg_val app_id) || error "配置文件缺少 app_id"
+    APP_SECRET=$(_cfg_val app_secret) || error "配置文件缺少 app_secret"
+    OPEN_ID=$(_cfg_val open_id) || error "配置文件缺少 open_id"
+
+    step "Step 1/2  验证 API 连接"
+    TOKEN=$(LARK_APP_ID="$APP_ID" LARK_APP_SECRET="$APP_SECRET" python3 -c "
+import json, urllib.request, sys, os
+req = urllib.request.Request(
+    'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal/',
+    data=json.dumps({'app_id': os.environ['LARK_APP_ID'], 'app_secret': os.environ['LARK_APP_SECRET']}).encode(),
+    headers={'Content-Type': 'application/json'}, method='POST')
+try:
+    data = json.loads(urllib.request.urlopen(req, timeout=10).read())
+    if data.get('code') == 0: print(data['tenant_access_token'])
+    else: print('FAIL:' + data.get('msg',''), file=sys.stderr); sys.exit(1)
+except Exception as e: print('FAIL:' + str(e), file=sys.stderr); sys.exit(1)
+" 2>&1) || error "API 连接失败，请检查配置文件中的凭证"
+    ok "飞书 API 连接成功"
+
+    step "Step 2/2  安装 hooks"
+else
 # ══════════════════════════════════════════════════════════════════════
 #  Step 1: Collect Bot Credentials
 # ══════════════════════════════════════════════════════════════════════
@@ -191,6 +233,8 @@ with open(os.environ['LARK_CONFIG_FILE'], 'w') as f: json.dump(cfg, f, indent=4)
 "
 chmod 600 "$CONFIG_FILE"
 ok "配置已保存  $CONFIG_FILE"
+
+fi  # end of interactive vs hooks-only
 
 # Install Claude Code hooks
 HOOK_CMD="python3 $NOTIFY_SCRIPT"


### PR DESCRIPTION
## Summary

修复 #1 中报告的 Windows 兼容性和安装体验问题。

- **[P0] 修复 python3 硬编码 bug**: `install.ps1` 现在检测实际可用的 Python 命令（`python3` 或 `python`），而非硬编码 `python3`。Windows 上 `python3` 通常是 Microsoft Store 的重定向 stub（exit code 49），导致安装后 hooks 完全无法工作。
- **[P1] 非交互安装模式**: 当 `config.json` 已包含完整凭证时（如管理员通过 `admin-setup.sh` 生成），自动跳过凭证和身份查询步骤，直接验证 API 并安装 hooks。同时支持 `--hooks-only` 参数（`install.sh`）。
- **[P2] 调试日志**: 新增 `CLAUDE_LARK_DEBUG=1` 环境变量，开启后将详细日志写入 `~/.config/claude-lark/debug.log`，覆盖配置加载、API 调用、卡片发送和错误信息。
- **[P2] Windows chmod 文档**: 在 README 和安装脚本中说明 Windows 上 `chmod 600` 不生效的限制。

### 修改文件

| 文件 | 改动 |
|------|------|
| `scripts/install.ps1` | Python 检测重写、非交互模式、所有 `python3` 引用改为 `$PythonCmd` |
| `scripts/install.sh` | 非交互模式（自动检测 + `--hooks-only` 参数） |
| `claude_lark_notify.py` | `CLAUDE_LARK_DEBUG` 调试日志 |
| `README.md` | 调试 FAQ、环境变量表、Windows 说明 |
| `README_zh.md` | 同上（中文） |

## Test plan

- [x] 全部 70 个测试通过（`python -m pytest tests/ -v`）
- [ ] Windows 上运行 `install.ps1`，验证使用 `python` 而非 `python3`
- [ ] 在已有 config 的情况下运行安装器，验证跳过凭证步骤
- [ ] 设置 `CLAUDE_LARK_DEBUG=1` 后触发通知，检查 debug.log 内容

🤖 Generated with [Claude Code](https://claude.com/claude-code)